### PR TITLE
Fix devtest dependency install

### DIFF
--- a/scripts/devtest.sh
+++ b/scripts/devtest.sh
@@ -4,5 +4,14 @@ set -euo pipefail
 # Move to repository root
 cd "$(dirname "$0")/.."
 
+# Ensure uv is installed to manage dependencies
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv not found, installing with pip..." >&2
+  pip install uv
+fi
+
+# Install project dependencies to avoid ModuleNotFound errors during tests
+uv pip install -e . --system
+
 # Run only the tests for quick iteration
-pytest
+pytest "$@"


### PR DESCRIPTION
## Summary
- ensure `scripts/devtest.sh` installs project dependencies before running pytest

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6867035031f48322a523b4fb5b65e399