### PR TITLE
Fix CI uv pip install steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,8 @@ jobs:
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: |
-          uv pip install ruff pytest
-          uv pip install -e .
+          uv pip install ruff pytest --system
+          uv pip install -e . --system
       # Runs a single command using the runners shell
       - name: Welcome message
         run: echo Hello, world! Welcome PyElastica Build, lets start testing!
@@ -75,8 +75,8 @@ jobs:
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: |
-          uv pip install ruff pytest
-          uv pip install -e .
+          uv pip install ruff pytest --system
+          uv pip install -e . --system
       - name: Run formatting
         run: |
           ruff format .

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@v5
       - name: Install build tools
-        run: uv pip install build
+        run: uv pip install build --system
       - name: Build
         run: python -m build
       - name: Publish distribution 📦 to PyPI


### PR DESCRIPTION
## Summary
- update GitHub Actions to pass `--system` when installing with uv
- also fix publish workflow to install build tools with `--system`

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68671fffbde08322a98395f92692b290