### PR TITLE
Remove Python 3.10 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
         os: [ubuntu-latest, macos-latest] #, windows-latest] # Run macos tests if really required, since they charge 10 times more for macos
         include:
           - os: ubuntu-latest
@@ -56,11 +56,11 @@ jobs:
       - name: Run tests
         run: |
           pytest
-  report-coverage:  # Report coverage from python 3.10 and mac-os. May change later
+  report-coverage:  # Report coverage from macOS
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         os: [macos-latest]
         include:
           - os: macos-latest

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ version: 2
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-20.04
-  tools: {python: "3.10"}
+  tools: {python: "3.11"}
   jobs:
     post_create_environment:
       - pip install uv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,12 +44,12 @@ First **create the fork repository and clone** to your local machine.
 
 2. Virtual python workspace: `conda`, `pyenv`, or `venv`.
 
-We recommend using python version above 3.10.0.
+We recommend using python version above 3.11.0.
 
 ```bash
 conda create --name pyelastica-dev
 conda activate pyelastica-dev
-conda install python==3.10
+conda install python==3.11
 ```
 
 3. Install [`uv`](https://github.com/astral-sh/uv) and project dependencies.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Visit [www.cosseratrods.org][link-project-website] for more information and lear
 ## How to Start
 [![PyPI version][badge-pypi]][link-pypi] [![Documentation Status][badge-docs-status]][link-docs-status]
 
-PyElastica is compatible with Python 3.10 - 3.12.
+PyElastica is compatible with Python 3.11 - 3.12.
 
 ~~~bash
 $ pip install pyelastica

--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -2,10 +2,10 @@
 
 ## Instruction
 
-PyElastica requires Python 3.10 - 3.12, which needs to be installed prior to using PyElastica. For information on installing Python, see [here](https://realpython.com/installing-python/). If you are interested in using a package manager like Conda, see [here](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html).
+PyElastica requires Python 3.11 - 3.12, which needs to be installed prior to using PyElastica. For information on installing Python, see [here](https://realpython.com/installing-python/). If you are interested in using a package manager like Conda, see [here](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html).
 
 :::{note}
-Python versions above 3.10 are tested only in Ubuntu and Mac OS. For Windows 10, some of the dependencies might not yet be compatible.
+Python versions above 3.11 are tested only in Ubuntu and Mac OS. For Windows 10, some of the dependencies might not yet be compatible.
 :::
 
 The easiest way to install PyElastica is with `pip`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 "License :: OSI Approved :: MIT License",
 "Development Status :: 4 - Beta",
 "Programming Language :: Python",
-"Programming Language :: Python :: 3.10",
 "Programming Language :: Python :: 3.11",
 "Programming Language :: Python :: Implementation :: CPython",
 "Intended Audience :: Science/Research",
@@ -35,7 +34,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.11,<3.13"
 numba = "^0.61.2"
 numpy = ">=1.24,<1.29"
 scipy = "^1.12.0"


### PR DESCRIPTION
## Summary
- drop Python 3.10 from supported versions
- update docs, workflow and project metadata

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6867d0826b948322b0e959dacb2d2ba0